### PR TITLE
bugfix: return 'false' if email or password is empty or null

### DIFF
--- a/modules/security/src/main/java/org/protobeans/security/validation/SignInValidator.java
+++ b/modules/security/src/main/java/org/protobeans/security/validation/SignInValidator.java
@@ -32,8 +32,8 @@ public class SignInValidator implements ConstraintValidator<SignIn, SignInForm> 
 
     @Override
     public boolean isValid(SignInForm form, ConstraintValidatorContext context) {
-        if (form.getEmail() == null || form.getEmail().trim().isEmpty()) return true;
-        if (form.getPassword() == null || form.getPassword().trim().isEmpty()) return true;
+        if (form.getEmail() == null || form.getEmail().trim().isEmpty()) return false;
+        if (form.getPassword() == null || form.getPassword().trim().isEmpty()) return false;
         
         context.disableDefaultConstraintViolation();
 


### PR DESCRIPTION
if email or password is empty or null - then form is not valid